### PR TITLE
Add contribution guidelines and setup helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Contribution Guidelines
+
+This repository does not enforce a strict style checker but aims for readable Python 3.11 code. Contributors should format code with [Black](https://black.readthedocs.io/en/stable/) before committing:
+
+```bash
+black .
+```
+
+## Environment Setup
+
+Develop locally using a Python virtual environment. A sample setup script is provided in `setup_env.sh` which installs dependencies and exports recommended environment variables used by the Docker container (`PYTHONDONTWRITEBYTECODE` and `PYTHONUNBUFFERED`). Run it before starting the app:
+
+```bash
+bash setup_env.sh
+```
+
+The application can then be launched with:
+
+```bash
+uvicorn container_control:app --host 0.0.0.0 --port 8080
+```
+
+## Testing
+
+No automated tests are included, but you can verify the running service by calling the `/api/health` endpoint:
+
+```bash
+curl http://localhost:8080/api/health
+```
+
+A successful response looks like:
+
+```json
+{"status": "healthy"}
+```
+

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Basic environment setup for local development
+python3 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+export PYTHONDONTWRITEBYTECODE=1
+export PYTHONUNBUFFERED=1
+echo "Environment ready. Run 'uvicorn container_control:app --host 0.0.0.0 --port 8080' to start." 


### PR DESCRIPTION
## Summary
- document style and testing instructions in AGENTS.md
- add `setup_env.sh` for local environment setup

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6849db59456483208f6091224f1ea745