### PR TITLE
Support nested sitemap payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ Content-Type: application/json
 }
 ```
 
+The endpoint is backward compatible with the older format where the configuration
+keys appear at the top level:
+
+```json
+{
+  "Traffic Generator URL": "https://example.com",
+  "Traffic Generator DNS Override": "192.168.1.100",
+  "XFF Header Name": "X-Forwarded-For",
+  "Rate Limit": 10,
+  "Simulated Users": 5,
+  "Minimum Session Length": 30,
+  "Maximum Session Length": 300,
+  "sitemap": { ... }
+}
+```
+
+Additionally, if the `sitemap` object includes metadata (e.g. `id`, `name`, and a
+nested `sitemap` field), the inner `sitemap` is automatically extracted.
+
 #### Stop Traffic Generation
 ```http
 POST /api/stop

--- a/container_control.py
+++ b/container_control.py
@@ -72,7 +72,11 @@ def _ensure_config_sitemap_structure(data: dict) -> dict:
     data["config"] = config
 
     if sitemap is not None:
-        data["sitemap"] = sitemap
+        # Support newer payload format where sitemap may include metadata under a nested 'sitemap' key
+        if isinstance(sitemap, dict) and "sitemap" in sitemap and isinstance(sitemap["sitemap"], dict):
+            data["sitemap"] = sitemap["sitemap"]
+        else:
+            data["sitemap"] = sitemap
 
     return data
 


### PR DESCRIPTION
## Summary
- handle new `sitemap` wrapper format in `/api/start`
- document compatibility with legacy start payloads

## Testing
- `bash setup_env.sh`
- `uvicorn container_control:app --host 0.0.0.0 --port 8080 &`
- `curl http://localhost:8080/api/health`

------
https://chatgpt.com/codex/tasks/task_b_6849dd942264832096f04b60e253bf06