### PR TITLE
Add tests for configuration validation and metrics

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -17,3 +17,20 @@ def test_metrics_window_behavior():
     rps_initial, rps_after = asyncio.run(run_test())
     assert rps_initial == 3
     assert rps_after == 0
+
+
+def test_metrics_partial_window():
+    metrics = Metrics()
+
+    async def run_test():
+        await metrics.increment()
+        await asyncio.sleep(0.6)
+        await metrics.increment()
+        rps_mid = await metrics.get_rps()
+        await asyncio.sleep(0.5)
+        rps_late = await metrics.get_rps()
+        return rps_mid, rps_late
+
+    rps_mid, rps_late = asyncio.run(run_test())
+    assert rps_mid == 2
+    assert rps_late == 1

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -1,0 +1,63 @@
+import pytest
+from pydantic import ValidationError
+
+from traffic_generator import (
+    ContainerConfig,
+    SiteMap,
+    PathDefinition,
+    Metrics,
+    TrafficGenerator,
+)
+
+
+def minimal_config(**overrides):
+    base = {
+        "Traffic Generator URL": "http://example.com",
+        "XFF Header Name": "X-Forwarded-For",
+        "Rate Limit": 1,
+        "Simulated Users": 1,
+        "Minimum Session Length": 1,
+        "Maximum Session Length": 1,
+    }
+    base.update(overrides)
+    return ContainerConfig(**base)
+
+
+def minimal_sitemap(**overrides):
+    base = {
+        "has_auth": False,
+        "paths": [PathDefinition(method="GET", paths=["/"], traffic_type="web")],
+    }
+    base.update(overrides)
+    return SiteMap(**base)
+
+
+def test_container_config_dns_override_blank():
+    cfg = minimal_config(**{"Traffic Generator DNS Override": ""})
+    assert cfg.traffic_target_dns_override is None
+
+
+def test_container_config_invalid_dns():
+    with pytest.raises(ValidationError):
+        minimal_config(**{"Traffic Generator DNS Override": "not_an_ip"})
+
+
+def test_sitemap_requires_auth_config():
+    with pytest.raises(ValidationError):
+        minimal_sitemap(has_auth=True)
+
+
+def test_sitemap_auth_ignored_when_disabled():
+    sm = minimal_sitemap(
+        has_auth=False, auth={"auth_type": "", "auth_path": "", "auth_method": ""}
+    )
+    assert sm.auth is None
+
+
+def test_match_path_variations():
+    tg = TrafficGenerator(minimal_config(), minimal_sitemap(), Metrics())
+
+    assert tg.match_path("/users/123", "/users/@id") is True
+    assert tg.match_path("/users/123/profile", "/users/@id/profile") is True
+    assert tg.match_path("/users/123/profile", "/users/@id") is False
+    assert tg.match_path("/posts/1", "/users/@id") is False


### PR DESCRIPTION
## Summary
- test DNS override validation and SiteMap auth logic
- expand Metrics tests with partial window scenario
- verify match_path helper for routing patterns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6849e3db423483208e9efa38b9d44aa1