### PR TITLE
Maintain loop until stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ keys appear at the top level:
 Additionally, if the `sitemap` object includes metadata (e.g. `id`, `name`, and a
 nested `sitemap` field), the inner `sitemap` is automatically extracted.
 
+Once started, the traffic generator's event loop will continue running until the
+`/api/stop` endpoint is called.
+
 #### Stop Traffic Generation
 ```http
 POST /api/stop

--- a/container_control.py
+++ b/container_control.py
@@ -110,6 +110,8 @@ def run_traffic_generator_in_loop(config, sitemap):
         traffic_generator_instance = TrafficGenerator(config, sitemap, Metrics())
         logger.info("Starting traffic generation...")
         event_loop.run_until_complete(traffic_generator_instance.start_generating())
+        # Keep the loop running until explicitly stopped
+        event_loop.run_forever()
     except asyncio.CancelledError:
         logger.info("Traffic generation cancelled.")
     except Exception as e:


### PR DESCRIPTION
## Summary
- keep the asyncio loop running after starting the generator
- document that the event loop runs until `/api/stop`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a5ee7a5508320a422f064e0f21953