### PR TITLE
Enable debug logging via config

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,44 @@
+import logging
+from traffic_generator import (
+    ContainerConfig,
+    SiteMap,
+    PathDefinition,
+    TrafficGenerator,
+    Metrics,
+    console_handler,
+    logger,
+)
+
+
+def minimal_config(**overrides):
+    base = {
+        "Traffic Generator URL": "http://example.com",
+        "XFF Header Name": "X-Forwarded-For",
+        "Rate Limit": 1,
+        "Simulated Users": 1,
+        "Minimum Session Length": 1,
+        "Maximum Session Length": 1,
+        "Debug": True,
+    }
+    base.update(overrides)
+    return ContainerConfig(**base)
+
+
+def minimal_sitemap(**overrides):
+    base = {
+        "has_auth": False,
+        "paths": [PathDefinition(method="GET", paths=["/"], traffic_type="web")],
+    }
+    base.update(overrides)
+    return SiteMap(**base)
+
+
+def test_debug_logging_enabled(caplog):
+    TrafficGenerator(minimal_config(), minimal_sitemap(), Metrics())
+    assert console_handler.level == logging.DEBUG
+    with caplog.at_level(logging.DEBUG, logger="Traffic Generator"):
+        logger.debug("debug active")
+    assert any(
+        rec.levelno == logging.DEBUG and rec.message == "debug active"
+        for rec in caplog.records
+    )

--- a/traffic_generator.py
+++ b/traffic_generator.py
@@ -689,8 +689,10 @@ class TrafficGenerator:
     def configure_logging(self, debug: bool):
         if debug:
             logger.setLevel(logging.DEBUG)
+            console_handler.setLevel(logging.DEBUG)
         else:
             logger.setLevel(logging.INFO)
+            console_handler.setLevel(logging.INFO)
 
     def create_session(self) -> aiohttp.ClientSession:
         # Note: DNS override is handled by constructing the URL with the IP,


### PR DESCRIPTION
## Summary
- update `configure_logging` to change handler level
- test debug logging using caplog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a60208bb88320b7b5e8682f3999e2